### PR TITLE
Fix card centering and prevent scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -656,12 +656,21 @@ select.form-control {
 
 /* Application-specific styles */
 .container {
-    min-height: 100vh;
+    height: 100vh;
+    overflow: hidden;
     background-color: white;
     display: flex;
     flex-direction: column;
     align-items: center;
     padding: var(--space-32) var(--space-16);
+    box-sizing: border-box;
+}
+
+main {
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .header {


### PR DESCRIPTION
## Summary
- set container height to `100vh` and hide overflow
- vertically center card by making `<main>` a flexbox

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685010ec3ff083298fed9ead36e9eccc