### PR TITLE
Handle invalid card display

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,8 @@ function generateStamps() {
 const stampsContainer = document.getElementById('stamps-container');
 const collectedCountElement = document.getElementById('collected-count');
 const totalCountElement = document.getElementById('total-count');
+const progressTextElement = document.getElementById('progress-text');
+const errorMessageElement = document.getElementById('error-message');
 const queryValueElement = document.getElementById('query-value');
 
 // Read the part of the URL after the '?'
@@ -88,7 +90,18 @@ function renderStamps() {
 }
 
 // Function to update progress information
-function updateProgressInfo() {
+function updateProgressInfo(hasError) {
+    if (hasError) {
+        if (progressTextElement) progressTextElement.classList.add('hidden');
+        if (errorMessageElement) {
+            errorMessageElement.textContent = 'Invalid code';
+            errorMessageElement.classList.remove('hidden');
+        }
+        return;
+    }
+
+    if (progressTextElement) progressTextElement.classList.remove('hidden');
+    if (errorMessageElement) errorMessageElement.classList.add('hidden');
     collectedCountElement.textContent = appData.collectedStamps;
     totalCountElement.textContent = appData.totalStamps;
 }
@@ -128,7 +141,7 @@ async function initApp() {
     }
 
     renderStamps();
-    updateProgressInfo();
+    updateProgressInfo(!hasData);
 
     // Add animations after a short delay to ensure DOM is ready
     setTimeout(addStampAnimations, 100);

--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@
                 </div>
                 
                 <div class="card-info">
-                    <p class="progress-text"><span id="collected-count">0</span> of <span id="total-count">10</span> stamps</p>
+                    <p id="progress-text" class="progress-text"><span id="collected-count">0</span> of <span id="total-count">10</span> stamps</p>
+                    <p id="error-message" class="error-text hidden"></p>
                     <p id="query-value" class="progress-text"></p>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -770,6 +770,11 @@ main {
 .error-mark {
     font-size: 28px;
     font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
 }
 
 .card-info {
@@ -789,6 +794,13 @@ main {
     color: var(--color-text-secondary);
     margin: 0;
     font-style: italic;
+}
+
+.error-text {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-error);
+    margin: var(--space-8) 0 0 0;
 }
 
 /* Responsive design */


### PR DESCRIPTION
## Summary
- center the error icon with flexbox
- hide progress information when the ID is wrong and show an error message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852914746548329b4ed1f94ac4aaab4