### PR TITLE
Fix layout for error stamp

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,8 +136,10 @@ async function initApp() {
         appData.totalStamps = 1;
         appData.collectedStamps = 0;
         appData.stamps = [{ id: 1, error: true }];
+        stampsContainer.classList.add('single-stamp');
     } else {
         generateStamps();
+        stampsContainer.classList.remove('single-stamp');
     }
 
     renderStamps();

--- a/style.css
+++ b/style.css
@@ -712,6 +712,12 @@ main {
     justify-items: center;
 }
 
+/* When only a single stamp is shown (e.g. error state),
+   center it by using a single grid column */
+.stamps-container.single-stamp {
+    grid-template-columns: 1fr;
+}
+
 .stamp {
     width: 56px;
     height: 56px;


### PR DESCRIPTION
## Summary
- center error state stamp by reducing grid columns
- toggle single-stamp class when data fetch fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685293243844832997a2c0f6bb4dd80c