### PR TITLE
Use Firestore logo

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,12 +45,28 @@ const totalCountElement = document.getElementById('total-count');
 const progressTextElement = document.getElementById('progress-text');
 const errorMessageElement = document.getElementById('error-message');
 const queryValueElement = document.getElementById('query-value');
+const companyLogoElement = document.getElementById('company-logo');
 
 // Read the part of the URL after the '?'
 function readQueryValue() {
     return window.location.search
         ? window.location.search.substring(1)
         : '';
+}
+
+// Load header logo from Firestore
+async function loadHeaderLogo() {
+    if (!companyLogoElement) return;
+    try {
+        const logoRef = doc(db, 'kiyosa', 'headerimage');
+        const logoSnap = await getDoc(logoRef);
+        if (logoSnap.exists() && logoSnap.data().url) {
+            companyLogoElement.src = logoSnap.data().url;
+            companyLogoElement.alt = `${appData.companyName} logo`;
+        }
+    } catch (e) {
+        console.error('Failed to load header logo', e);
+    }
 }
 
 // Function to create a stamp element
@@ -126,6 +142,7 @@ function addStampAnimations() {
 
 // Initialize the application
 async function initApp() {
+    await loadHeaderLogo();
     appData.queryValue = readQueryValue();
     if (queryValueElement) {
         queryValueElement.textContent = appData.queryValue;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
     <div class="container">
         <header class="header">
-            <h1 class="company-name">Coffee Corner</h1>
+            <img id="company-logo" class="company-logo" alt="Coffee Corner logo">
         </header>
         
         <main>

--- a/style.css
+++ b/style.css
@@ -687,6 +687,13 @@ main {
     letter-spacing: var(--letter-spacing-tight);
 }
 
+.company-logo {
+    display: block;
+    max-height: 40px;
+    width: auto;
+    margin: 0 auto;
+}
+
 .card {
     background-color: var(--color-surface);
     border-radius: var(--radius-lg);
@@ -814,9 +821,13 @@ main {
     .container {
         padding: var(--space-20) var(--space-12);
     }
-    
+
     .company-name {
         font-size: var(--font-size-3xl);
+    }
+
+    .company-logo {
+        max-height: 32px;
     }
     
     .card {
@@ -844,6 +855,10 @@ main {
 @media (max-width: 320px) {
     .stamps-container {
         gap: var(--space-8);
+    }
+
+    .company-logo {
+        max-height: 28px;
     }
     
     .stamp {


### PR DESCRIPTION
## Summary
- pull header logo URL from Firestore
- replace company name heading with image
- style logo to match previous heading size

## Testing
- `npm -s test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68529858029483299db78aa9d61ee1a6