### PR TITLE
Use Firestore header image

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,27 @@ const totalCountElement = document.getElementById('total-count');
 const progressTextElement = document.getElementById('progress-text');
 const errorMessageElement = document.getElementById('error-message');
 const queryValueElement = document.getElementById('query-value');
+const headerLogoElement = document.getElementById('header-logo');
+const companyNameElement = document.getElementById('company-name');
+
+async function loadHeaderImage() {
+    try {
+        const ref = doc(db, 'kiyosa', 'headerimage');
+        const snap = await getDoc(ref);
+        if (snap.exists()) {
+            const data = snap.data();
+            if (data.url && headerLogoElement) {
+                headerLogoElement.src = data.url;
+                headerLogoElement.classList.remove('hidden');
+                if (companyNameElement) {
+                    companyNameElement.classList.add('hidden');
+                }
+            }
+        }
+    } catch (e) {
+        console.error('Error loading header image', e);
+    }
+}
 
 // Read the part of the URL after the '?'
 function readQueryValue() {
@@ -130,6 +151,8 @@ async function initApp() {
     if (queryValueElement) {
         queryValueElement.textContent = appData.queryValue;
     }
+
+    loadHeaderImage();
 
     const hasData = await readData(appData.queryValue);
     if (!hasData) {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
 <body>
     <div class="container">
         <header class="header">
-            <h1 class="company-name">Coffee Corner</h1>
+            <img id="header-logo" class="header-logo hidden" alt="Company logo" />
+            <h1 id="company-name" class="company-name">Coffee Corner</h1>
         </header>
         
         <main>

--- a/style.css
+++ b/style.css
@@ -687,6 +687,13 @@ main {
     letter-spacing: var(--letter-spacing-tight);
 }
 
+.header-logo {
+    height: var(--font-size-4xl);
+    width: auto;
+    display: block;
+    margin: 0 auto;
+}
+
 .card {
     background-color: var(--color-surface);
     border-radius: var(--radius-lg);
@@ -817,6 +824,10 @@ main {
     
     .company-name {
         font-size: var(--font-size-3xl);
+    }
+
+    .header-logo {
+        height: var(--font-size-3xl);
     }
     
     .card {


### PR DESCRIPTION
## Summary
- fetch header logo from Firestore
- hide default header text when logo is loaded
- show header image with sizes that match the old heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68529858029483299db78aa9d61ee1a6