### PR TITLE
Restyle QR popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,10 @@
                 <span>Show QR Code</span>
             </button>
             <div id="qr-overlay" class="qr-overlay hidden">
-                <button id="qr-close" class="qr-close">×</button>
-                <canvas id="qr-canvas"></canvas>
+                <div class="qr-popup">
+                    <button id="qr-close" class="qr-close">×</button>
+                    <canvas id="qr-canvas"></canvas>
+                </div>
             </div>
         </main>
         <footer class="footer">

--- a/style.css
+++ b/style.css
@@ -894,7 +894,7 @@ main {
 .qr-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0,0,0,0.6);
+    background: rgba(0, 0, 0, 0.6);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -903,15 +903,26 @@ main {
 .qr-overlay.hidden {
     display: none;
 }
+.qr-popup {
+    position: relative;
+    background: #555;
+    padding: var(--space-24) var(--space-20);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+}
 .qr-close {
     position: absolute;
-    top: 12px;
-    right: 12px;
+    top: var(--space-8);
+    right: var(--space-8);
     background: none;
     border: none;
     font-size: 24px;
     color: #fff;
     cursor: pointer;
+}
+#qr-canvas {
+    display: block;
+    border-radius: var(--radius-sm);
 }
 
 /* Show QR Code button */


### PR DESCRIPTION
## Summary
- redesign QR code overlay to use a small grey popover
- give QR code and popup rounded corners
- move close button inside popup in top-right
- darken popup grey and enlarge padding for a vertical layout

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852b91cbba88329a9ce2ad78aa3f96d