### PR TITLE
Update qrcode icon color for light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -956,3 +956,13 @@ main {
     width: 20px;
     height: 20px;
 }
+
+@media (prefers-color-scheme: light) {
+    .qr-button__icon {
+        filter: invert(1);
+    }
+}
+
+[data-color-scheme="light"] .qr-button__icon {
+    filter: invert(1);
+}


### PR DESCRIPTION
## Summary
- invert QR code icon in light mode so it appears black

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c3c9e3c08329afeff06632d4d08e