### PR TITLE
Add start form for QR code parameter

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,6 +91,10 @@ const qrOverlay = document.getElementById('qr-overlay');
 const qrClose = document.getElementById('qr-close');
 const qrCanvas = document.getElementById('qr-canvas');
 const qrParamElement = document.getElementById('qr-param-text');
+const startForm = document.getElementById('start-form');
+const queryInput = document.getElementById('query-input');
+const queryGo = document.getElementById('query-go');
+const cardElement = document.getElementById('card');
 
 qrBtn.addEventListener('click', () => {
     QRCode.toCanvas(qrCanvas, window.location.href, { width: 240, margin: 2 });
@@ -103,6 +107,27 @@ qrBtn.addEventListener('click', () => {
 qrClose.addEventListener('click', () => {
     qrOverlay.classList.add('hidden');
 });
+
+if (queryGo) {
+    queryGo.addEventListener('click', () => {
+        if (!queryInput) return;
+        let val = queryInput.value.trim();
+        if (val.length < 5) {
+            val = val.padStart(5, '0');
+        }
+        if (val) {
+            window.location.href = `${window.location.pathname}?${encodeURIComponent(val)}`;
+        }
+    });
+    if (queryInput) {
+        queryInput.addEventListener('keypress', e => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                queryGo.click();
+            }
+        });
+    }
+}
 
 function applyTranslations() {
     const t = translations[currentLang] || translations.en;
@@ -224,6 +249,12 @@ async function initApp() {
     applyTranslations();
     await loadHeaderLogo();
     appData.queryValue = readQueryValue();
+    if (!appData.queryValue) {
+        if (startForm) startForm.classList.remove('hidden');
+        if (cardElement) cardElement.classList.add('hidden');
+        if (qrBtn) qrBtn.classList.add('hidden');
+        return;
+    }
     if (queryValueElement) {
         queryValueElement.textContent = appData.queryValue;
     }

--- a/index.html
+++ b/index.html
@@ -15,7 +15,11 @@
         </header>
         
         <main>
-            <div class="card">
+            <div id="start-form" class="hidden" style="text-align: center;">
+                <input id="query-input" class="form-control" type="text" placeholder="Code" />
+                <button id="query-go" class="btn qr-button">Go</button>
+            </div>
+            <div id="card" class="card">
                 <div class="stamps-container" id="stamps-container">
                     <!-- Stamps will be rendered here by JavaScript -->
                 </div>


### PR DESCRIPTION
## Summary
- show a start form when no query parameter is provided
- hide the loyalty card and QR button until a code is entered
- pad code to five characters and redirect on "Go"

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6856dc7367d0832989047809e5e7087c