### PR TITLE
Add manual code input on base URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,10 @@ const qrClose = document.getElementById('qr-close');
 const qrCanvas = document.getElementById('qr-canvas');
 const qrParamElement = document.getElementById('qr-param-text');
 
+const searchContainer = document.getElementById("search-container");
+const codeInput = document.getElementById("code-input");
+const goBtn = document.getElementById("go-btn");
+const cardElement = document.querySelector(".card");
 qrBtn.addEventListener('click', () => {
     QRCode.toCanvas(qrCanvas, window.location.href, { width: 240, margin: 2 });
     if (qrParamElement) {
@@ -100,6 +104,17 @@ qrBtn.addEventListener('click', () => {
     qrOverlay.classList.remove('hidden');
 });
 
+function handleGo() {
+    if (!codeInput) return;
+    let val = codeInput.value.trim();
+    if (val.length < 5) {
+        val = val.padStart(5, "0");
+    }
+    window.location.href = `${window.location.pathname}?${encodeURIComponent(val)}`;
+}
+
+goBtn && goBtn.addEventListener("click", handleGo);
+codeInput && codeInput.addEventListener("keypress", e => { if (e.key === "Enter") handleGo(); });
 qrClose.addEventListener('click', () => {
     qrOverlay.classList.add('hidden');
 });
@@ -226,6 +241,12 @@ async function initApp() {
     appData.queryValue = readQueryValue();
     if (queryValueElement) {
         queryValueElement.textContent = appData.queryValue;
+    }
+    if (!appData.queryValue) {
+        if (searchContainer) searchContainer.classList.remove("hidden");
+        if (cardElement) cardElement.classList.add("hidden");
+        if (qrBtn) qrBtn.classList.add("hidden");
+        return;
     }
 
     const hasData = await readData(appData.queryValue);

--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
         </header>
         
         <main>
+            <div id="search-container" class="hidden">
+                <input id="code-input" class="form-control" type="text" maxlength="5">
+                <button id="go-btn" class="btn qr-button">Go</button>
+            </div>
             <div class="card">
                 <div class="stamps-container" id="stamps-container">
                     <!-- Stamps will be rendered here by JavaScript -->

--- a/style.css
+++ b/style.css
@@ -966,3 +966,9 @@ main {
 [data-color-scheme="light"] .qr-button__icon {
     filter: invert(1);
 }
+
+#search-container {
+    display: flex;
+    gap: var(--space-8);
+    margin-top: var(--space-16);
+}


### PR DESCRIPTION
## Summary
- add code input field and Go button on the home page
- style search container to match QR code button
- implement JavaScript logic for redirecting to `?code` and hiding/showing UI elements

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856dc7367d0832989047809e5e7087c